### PR TITLE
Add ITF-37 privacy docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-pytest -q
+	pytest -q

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,5 @@ This directory contains detailed guides for using the conversion scripts.
 Refer to `ARCHITECTURE.md` for a high level overview,
 `MANUAL_WORKFLOW.md` for the step by step workflow,
 and `PRIVATE_OVERLAY.md` for overlay usage.
+
+See the ITF-37 privacy series in `itf37/` for details on dual work environment security.

--- a/docs/diagrams/itf37-environment-flow.mermaid
+++ b/docs/diagrams/itf37-environment-flow.mermaid
@@ -1,0 +1,12 @@
+flowchart TD
+    A[Developer] --> B{Environment?}
+    B -->|Company| C[Load company_profile.yaml]
+    B -->|Home| D[Load generic_profile.yaml]
+    C --> E[Private Configs]
+    D --> F[Generic Configs]
+    E --> G[Access Real Resources]
+    F --> H[Access Mock Services]
+    G --> I[Run Tests]
+    H --> I
+    I --> J[workflow.py public]
+    J --> K[Commit Templates]

--- a/docs/diagrams/itf37-network-isolation.mermaid
+++ b/docs/diagrams/itf37-network-isolation.mermaid
@@ -1,0 +1,10 @@
+flowchart TD
+    subgraph Home_Network
+        A[Developer Laptop]
+        A --> B[Mock Services]
+    end
+    subgraph Company_Network
+        C[Developer Workstation]
+        C --> D[Internal Resources]
+    end
+    B -. no access .-> D

--- a/docs/itf37/ITF37_Developer_Privacy_Guide.md
+++ b/docs/itf37/ITF37_Developer_Privacy_Guide.md
@@ -1,0 +1,60 @@
+# ITF-37 Developer Privacy Guide
+
+This guide provides daily workflow steps for working safely with the templated dual environment.
+
+## 1. Setup Profiles
+
+Place the following YAML profiles outside version control:
+
+```yaml
+# company_profile.yaml
+work_environments:
+  company_environment:
+    profile: "company_profile.yaml"
+    location: "conversion-tools/.workflow-temp/"
+    contains: "Real IPs, Jama tokens, internal resources"
+    visibility: "Private, never committed"
+  home_environment:
+    profile: "generic_profile.yaml"
+    location: "conversion-tools/.workflow-temp/"
+    contains: "Generic IPs, mock services, public tools"
+    visibility: "Safe for home networks"
+```
+
+## 2. Daily Workflow
+
+1. **Pull latest templates**
+   ```bash
+   git pull
+   ```
+2. **Generate private files**
+   ```bash
+   workflow.py private --profile company_profile.yaml
+   ```
+3. **Run tests**
+   Execute your normal integration tests or automation using the generated configs.
+4. **Revert to public files**
+   ```bash
+   workflow.py public
+   ```
+5. **Commit changes**
+   ```bash
+   git add .
+   git commit -m "Update tests"
+   ```
+6. **Push**
+   ```bash
+   git push
+   ```
+
+## 3. Common Pitfalls
+
+- Forgetting to run `workflow.py public` before committing. Use a pre-commit hook if available.
+- Storing `company_profile.yaml` in the repository. Keep it on your workstation only.
+- Running tests against production hardware from home. Use the generic profile instead.
+
+## 4. Troubleshooting
+
+If `workflow.py private` fails, check that your profile file paths are correct and that the `.workflow-temp/` directory is writable. If pre-commit hooks block your commit, run `workflow.py public` again and ensure no private files remain.
+
+Follow this guide to ensure all team members maintain privacy compliance during daily development.

--- a/docs/itf37/ITF37_Privacy_Architecture_Documentation.md
+++ b/docs/itf37/ITF37_Privacy_Architecture_Documentation.md
@@ -1,0 +1,174 @@
+# ITF-37 Privacy Architecture Documentation
+
+## Executive Summary
+
+The templated dual work environment system protects company privacy by ensuring no sensitive information ever resides in source control. Developers seamlessly switch between sanitized home setups and fully featured company environments without risking leaks. This approach aligns with corporate security policy, enables compliance audits, and mitigates exposure risk.
+
+## Table of Contents
+1. [Objective](#objective)
+2. [Risk Mitigation](#risk-mitigation)
+3. [Compliance Alignment](#compliance-alignment)
+4. [Technical Architecture Overview](#technical-architecture-overview)
+5. [Privacy Controls Detail](#privacy-controls-detail)
+6. [Home Development Security](#home-development-security)
+7. [Company Environment Security](#company-environment-security)
+8. [Developer Workflow Documentation](#developer-workflow-documentation)
+9. [Compliance and Audit](#compliance-and-audit)
+10. [Security Considerations](#security-considerations)
+11. [Integration with Company Policies](#integration-with-company-policies)
+
+<a name="objective"></a>
+
+## Objective
+
+This document explains how the ITF templated workflow allows developers to work both from home and in the office using the same codebase while preventing accidental exposure of confidential data. By leveraging placeholders for all secrets and environment-specific values, the framework enforces security across the development lifecycle.
+
+<a name="risk-mitigation"></a>
+
+## Risk Mitigation
+
+* **No secrets in version control.** Template files only contain placeholders like `{{ API_KEY }}` preventing hard-coded credentials.
+* **Automatic conversion workflow.** `workflow.py private` inserts real values when needed and `workflow.py public` cleans them before commits.
+* **Dual profile enforcement.** Separate profiles keep private infrastructure inaccessible outside the office.
+
+<a name="compliance-alignment"></a>
+
+## Compliance Alignment
+
+The system aligns with security standards such as GDPR and SOX by keeping sensitive data in isolated profiles, logging access to real configurations, and ensuring sanitized code is always stored in Git.
+
+<a name="technical-architecture-overview"></a>
+
+## Technical Architecture Overview
+
+```mermaid
+flowchart TD
+    A[Developer] --> B{Environment?}
+    B -->|Company| C[Load company_profile.yaml]
+    B -->|Home| D[Load generic_profile.yaml]
+    C --> E[Real IP: {{ COMPANY_JAMA_IP }}]
+    D --> F[Mock IP: {{ GENERIC_JAMA_IP }}]
+    E --> G[Access Real Jama/Hardware]
+    F --> H[Access Mock Services]
+    G --> I[workflow.py public before commit]
+    H --> J[Safe to commit templates]
+```
+
+Developers run the same tests in either environment because the framework injects the appropriate configuration at runtime.
+
+<a name="privacy-controls-detail"></a>
+
+## Privacy Controls Detail
+
+### Template Placeholder System
+
+All configuration files reference variables using the `{{ VARIABLE }}` syntax. For example:
+
+```yaml
+jama_config:
+  base_url: "{{ JAMA_BASE_URL }}"
+  api_key: "{{ JAMA_API_KEY }}"
+  project_id: "{{ JAMA_PROJECT_ID }}"
+
+device_config:
+  moxa_device: "{{ MOXA_IP_ADDRESS }}"
+  test_ports: "{{ TEST_PORT_RANGE }}"
+```
+
+### Conversion Tool Security
+
+The `workflow.py` tool tracks every file that is converted from template to private form. It prevents accidental commits of private data by requiring `workflow.py public` to be run before pushing.
+
+### File System Isolation
+
+Generated private files reside in `.workflow-temp/` and are excluded from version control, keeping sensitive data out of the repo.
+
+### Git Hook Protection
+
+Optional pre-commit hooks scan for tokens or IP patterns to ensure no private information remains.
+
+<a name="home-development-security"></a>
+
+## Home Development Security
+
+* **Generic Profile Usage.** Developers at home load `generic_profile.yaml` which contains mock services and public resources only.
+* **Mock Service Integration.** Generic services simulate company hardware so tests remain valid.
+* **Network Isolation.** The home environment has no direct access to internal company infrastructure.
+* **Code Portability.** Because the same placeholders are used, code runs the same tests in either environment.
+
+<a name="company-environment-security"></a>
+
+## Company Environment Security
+
+* **Temporary File Management.** Real configs are generated only inside `.workflow-temp/` and deleted by `workflow.py public`.
+* **Access Control.** Only authorized users possess the `company_profile.yaml` file.
+* **Audit Trail.** Usage of real data is logged for review.
+* **Cleanup Verification.** Before commits, the tool confirms that all private files have been removed from the working tree.
+
+<a name="developer-workflow-documentation"></a>
+
+## Developer Workflow Documentation
+
+Daily development cycle:
+
+```bash
+# 1. Get latest templates
+git pull
+# 2. Generate private configs
+workflow.py private --profile company_profile.yaml
+# ... run tests against real hardware ...
+# 3. Clean workspace for commit
+workflow.py public
+# 4. Commit only sanitized files
+git add .
+git commit -m "Update tests"
+# 5. Push safely
+git push
+```
+
+<a name="compliance-and-audit"></a>
+
+## Compliance and Audit
+
+* **Security Review Process.** Changes to the privacy system are reviewed by security leads.
+* **Audit Logging.** Access to `company_profile.yaml` and runs of `workflow.py private` are logged.
+* **Incident Response.** If real data is exposed, triggers notify the security team and instructions for rotating credentials are followed.
+* **Regular Reviews.** Quarterly audits verify adherence to privacy procedures.
+
+<a name="security-considerations"></a>
+
+## Security Considerations
+
+### Threat Model
+
+The system protects against the following threats:
+* Accidental commits of credentials.
+* Unauthorized access to company infrastructure from home.
+* Data exfiltration via public repositories.
+
+### Attack Scenarios
+
+An attacker with access only to the public repository cannot obtain company secrets because the profiles and temporary files are ignored by Git. Even if a developer mistakenly commits the `.workflow-temp/` directory, pre-commit hooks flag the presence of IP addresses or API keys.
+
+### Defense in Depth
+
+1. Template substitution ensures no hardcoded secrets.
+2. Dual profiles segregate production and home environments.
+3. Git hooks and code review catch remaining issues.
+
+### Failure Modes
+
+If a developer forgets to run `workflow.py public`, the commit will include files containing placeholders or real data. The pre-commit checks halt the process and instruct the developer to clean their workspace.
+
+<a name="integration-with-company-policies"></a>
+
+## Integration with Company Policies
+
+* **Data Classification.** Templates are classified as public while profiles containing real data are restricted.
+* **Remote Work Policy.** The home environment uses sanitized values and prevents access to internal networks, conforming to remote work guidelines.
+* **Third-Party Access.** Contractors can clone the repository and work with generic profiles without seeing company data.
+* **Regulatory Compliance.** Keeping sensitive data in isolated profiles supports GDPR and SOX requirements for data minimization and auditability.
+
+---
+
+This document illustrates how the templated dual work environment enables flexible development while upholding strict privacy guarantees. The following guides and checklist further detail the day-to-day process and verification steps.

--- a/docs/itf37/ITF37_Privacy_Compliance_Checklist.md
+++ b/docs/itf37/ITF37_Privacy_Compliance_Checklist.md
@@ -1,0 +1,19 @@
+# ITF-37 Privacy Compliance Checklist
+
+Use this checklist before each commit to ensure no company data is exposed.
+
+## Pre-Commit Verification
+
+- [ ] Run `workflow.py public` to remove private files.
+- [ ] Verify `.workflow-temp/` is absent or empty.
+- [ ] Search the diff for tokens like `{{ COMPANY_` or real IP addresses.
+- [ ] Ensure `company_profile.yaml` is not tracked by Git.
+- [ ] Run unit tests to confirm template conversions succeed.
+
+## Audit Trail Requirements
+
+- Logs for each invocation of `workflow.py private` must be retained.
+- Access to company profiles must be recorded in a secure log.
+- Any detected privacy violation should trigger an incident report.
+
+Follow this checklist to maintain compliance with corporate privacy policies.


### PR DESCRIPTION
## Summary
- document templated dual work environment privacy architecture
- provide developer guide and compliance checklist
- add diagrams showing environment flow and network isolation
- mention ITF-37 docs in main README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68559f2fa5a88333ae79339832240430