### PR TITLE
Rename workflow configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Create `.workflow-config.yaml`:
 ```yaml
 owner: "yourusername"
 repo: "your-repo"
-profile: "scripts/config_profiles/company_profile.yaml"
-temp_dir: ".workflow-temp"
-template: "template"
-overlay_dir: "private-overlay"  # optional private files
+placeholder_values: "scripts/config_profiles/company_profile.yaml"
+working_directory: ".workflow-temp"
+template_source_dir: "template"
+company_only_files: "private-overlay"  # optional private files
 ```
-The `overlay_dir` directory contains files that are only used in private mode.
+The `company_only_files` directory contains files that are only used in private mode.
 These files are automatically removed when creating the public version.
 See [docs/PRIVATE_OVERLAY.md](docs/PRIVATE_OVERLAY.md) for details.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
 The project consists only of local scripts. There is no server component.
-Files are converted by applying a profile and optional overlay before generating the public build.
+Files are converted by applying a placeholder values and optional overlay before generating the public build.
 
 ## Private Overlay
 See [PRIVATE_OVERLAY.md](PRIVATE_OVERLAY.md) for full details. In short, any

--- a/docs/PRIVATE_OVERLAY.md
+++ b/docs/PRIVATE_OVERLAY.md
@@ -11,7 +11,7 @@ copied on top of the template before tokens are replaced.
 ## How To Use
 1. Create a directory named `private-overlay` at the root of your repository.
    Mirror the layout of the files you want to override or add.
-2. In `.workflow-config.yaml` set the `overlay_dir` field if you use a custom
+2. In `.workflow-config.yaml` set the `company_only_files` field if you use a custom
    path. The default is `private-overlay`.
 3. Run `python workflow.py private` to build the private working directory.
    The overlay files will be copied into the workspace before token substitution.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,7 +4,7 @@ Repository visibility is controlled manually. Make the repository public only wh
 
 ## Best Practices
 
-- Keep private profile files outside of the repository.
+- Keep private placeholder values files outside of the repository.
 - Enable two-factor authentication on GitHub.
 - Review the diff after running `workflow.py public` to ensure no secrets remain.
 - Limit write access to the public repository.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-- If the public directory contains private data, ensure you reverted using the same profile used when injecting.
+- If the public directory contains private data, ensure you reverted using the same placeholder values used when injecting.
 - If `workflow.py` reports missing directories, copy the example configuration files again to recreate them.
 - When in doubt, delete the `.workflow-temp` directory and start again.
 
@@ -14,7 +14,7 @@ If you see syntax errors like `class ACME CorpClient:` after conversion:
    - `"123-test"` → `"test"` (removes leading digits)
    - Special characters are replaced with underscores
 
-3. **Best Practice**: Define separate keys for identifiers in your profile:
+3. **Best Practice**: Define separate keys for identifiers in your placeholder values:
    ```yaml
    COMPANY_NAME: "ACME Corp"  # For display
    COMPANY_CLASS: "ACMECorp"  # For class names

--- a/examples/.workflow-config.yaml.example
+++ b/examples/.workflow-config.yaml.example
@@ -1,6 +1,7 @@
 # Simplified .workflow-config.yaml using a flat structure
 owner: "USERNAME"
 repo: "REPO"
-profile: "scripts/config_profiles/company_profile.yaml"
-temp_dir: ".workflow-temp"
-template: "template"
+placeholder_values: "config_profiles/company_profile.yaml"
+template_source_dir: "templated-code"
+working_directory: "conversion-tools/.workflow-temp"
+company_only_files: "private-overlay"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ validate that no sensitive information remains.
 ### `apply_template_context.py`
 
 Copies a generic project to a new location and replaces `{{ KEY }}`
-placeholders using values from a YAML profile. Tokens can include optional
+placeholders using values from a YAML placeholder values file. Tokens can include optional
 whitespace, so both `{{KEY}}` and `{{ KEY }}` forms are replaced. An optional overlay
 folder can be provided to apply company‑specific files on top of the
 base project.  Every run writes a timestamped log file to the `log/`
@@ -18,19 +18,19 @@ directory and an optional `--verbose` flag prints those log lines to the
 screen.
 
 ```
-python scripts/apply_template_context.py <src> <dst> <profile> [--overlay <dir>] [--verbose]
+python scripts/apply_template_context.py <src> <dst> <placeholder_values> [--overlay <dir>] [--verbose]
 ```
 
 ### `revert_template_context.py`
 
 Copies a private project to a new location and replaces private values with
-their original `{{ KEY }}` placeholders using the same YAML profile.  The
+their original `{{ KEY }}` placeholders using the same YAML placeholder values file.  The
 replacement now uses regular expressions with word boundaries to avoid
 matching partial words.  Logging behaviour mirrors that of
 `apply_template_context.py`, writing to `log/` and supporting `--verbose`.
 
 ```
-python scripts/revert_template_context.py <src> <dst> <profile> [--verbose]
+python scripts/revert_template_context.py <src> <dst> <placeholder_values> [--verbose]
 ```
 
 ### `export_to_public.py`
@@ -76,7 +76,7 @@ python scripts/manage_logs.py --cleanup --days 30
 
 ## Configuration Profiles
 
-Example YAML profiles can be found under `scripts/config_profiles/`.
+Example YAML placeholder values files can be found under `scripts/config_profiles/`.
 They map placeholder names to actual values used by
 `apply_template_context.py`.
 

--- a/scripts/github_visibility.py
+++ b/scripts/github_visibility.py
@@ -4,13 +4,31 @@ import argparse
 import json
 from urllib import request
 
-from scripts.apply_template_context import load_profile
+import yaml
 
 DEFAULT_CONFIG = Path('.workflow-config.yaml')
 
 
 def load_config(path: Path = DEFAULT_CONFIG) -> dict:
-    return load_profile(path)
+    config = yaml.safe_load(open(path))
+
+    if "profile" in config and "placeholder_values" not in config:
+        config["placeholder_values"] = config["profile"]
+        print("Warning: 'profile' is deprecated, use 'placeholder_values' instead")
+
+    if "template" in config and "template_source_dir" not in config:
+        config["template_source_dir"] = config["template"]
+        print("Warning: 'template' is deprecated, use 'template_source_dir' instead")
+
+    if "temp_dir" in config and "working_directory" not in config:
+        config["working_directory"] = config["temp_dir"]
+        print("Warning: 'temp_dir' is deprecated, use 'working_directory' instead")
+
+    if "overlay_dir" in config and "company_only_files" not in config:
+        config["company_only_files"] = config["overlay_dir"]
+        print("Warning: 'overlay_dir' is deprecated, use 'company_only_files' instead")
+
+    return config
 
 
 def set_visibility(owner: str, repo: str, make_private: bool, token: str) -> None:

--- a/tests/MANUAL_TEST_INSTRUCTIONS.md
+++ b/tests/MANUAL_TEST_INSTRUCTIONS.md
@@ -4,7 +4,7 @@ Follow these steps to verify the workflow manually. They mirror the automated te
 
 1. Ensure `.workflow-config.yaml` exists in the repository root.
 2. Run `python workflow.py private` to create the private working copy.
-3. Modify files in `.workflow-temp/private` and confirm values from your profile were injected.
+3. Modify files in `.workflow-temp/private` and confirm values from your placeholder values file were injected.
 4. Run `python workflow.py public` to revert the private data back to placeholders.
 5. Inspect the diff to make sure no secrets remain in the `template` directory.
 6. (Optional) Check the current visibility state:

--- a/tests/integration/test_manual_workflow.py
+++ b/tests/integration/test_manual_workflow.py
@@ -10,26 +10,30 @@ class TestManualWorkflowEndToEnd:
 
     def test_home_to_company_flow(self, tmp_path):
         cfg = tmp_path / "config.yaml"
-        profile = tmp_path / "profile.yaml"
-        template = tmp_path / "template"
-        template.mkdir()
-        (template / "app.txt").write_text("v={{V}}")
-        profile.write_text("V: 1\n")
+        placeholder_values = tmp_path / "profile.yaml"
+        template_source_dir = tmp_path / "template"
+        template_source_dir.mkdir()
+        (template_source_dir / "app.txt").write_text("v={{V}}")
+        placeholder_values.write_text("V: 1\n")
         cfg.write_text(
-            f"profile: \"{profile}\"\ntemp_dir: \"{tmp_path}\"\ntemplate: \"{template}\"\n"
+            f"placeholder_values: \"{placeholder_values.as_posix()}\"\n"
+            f"working_directory: \"{tmp_path.as_posix()}\"\n"
+            f"template_source_dir: \"{template_source_dir.as_posix()}\"\n"
         )
         private_dir = workflow.private_workflow(cfg)
         assert (private_dir / "app.txt").read_text() == "v=1"
 
     def test_company_to_home_flow(self, tmp_path):
         cfg = tmp_path / "config.yaml"
-        profile = tmp_path / "profile.yaml"
-        template = tmp_path / "template"
-        template.mkdir()
-        (template / "app.txt").write_text("v={{V}}")
-        profile.write_text("V: 2\n")
+        placeholder_values = tmp_path / "profile.yaml"
+        template_source_dir = tmp_path / "template"
+        template_source_dir.mkdir()
+        (template_source_dir / "app.txt").write_text("v={{V}}")
+        placeholder_values.write_text("V: 2\n")
         cfg.write_text(
-            f"profile: \"{profile}\"\ntemp_dir: \"{tmp_path}\"\ntemplate: \"{template}\"\n"
+            f"placeholder_values: \"{placeholder_values.as_posix()}\"\n"
+            f"working_directory: \"{tmp_path.as_posix()}\"\n"
+            f"template_source_dir: \"{template_source_dir.as_posix()}\"\n"
         )
         private_dir = workflow.private_workflow(cfg)
         public_dir = workflow.public_workflow(cfg)
@@ -37,19 +41,21 @@ class TestManualWorkflowEndToEnd:
 
     def test_multi_developer_collaboration(self, tmp_path):
         cfg = tmp_path / "config.yaml"
-        profile = tmp_path / "profile.yaml"
-        template = tmp_path / "template"
-        template.mkdir()
-        (template / "a.txt").write_text("v={{V}}")
-        profile.write_text("V: 1\n")
+        placeholder_values = tmp_path / "profile.yaml"
+        template_source_dir = tmp_path / "template"
+        template_source_dir.mkdir()
+        (template_source_dir / "a.txt").write_text("v={{V}}")
+        placeholder_values.write_text("V: 1\n")
         cfg.write_text(
-            f"profile: \"{profile}\"\ntemp_dir: \"{tmp_path}\"\ntemplate: \"{template}\"\n"
+            f"placeholder_values: \"{placeholder_values.as_posix()}\"\n"
+            f"working_directory: \"{tmp_path.as_posix()}\"\n"
+            f"template_source_dir: \"{template_source_dir.as_posix()}\"\n"
         )
         workflow.private_workflow(cfg)
         (tmp_path / "private" / "a.txt").write_text("changed1")
         workflow.public_workflow(cfg)
 
-        profile.write_text("V: 2\n")
+        placeholder_values.write_text("V: 2\n")
         shutil.rmtree(tmp_path / "private", ignore_errors=True)
         shutil.rmtree(tmp_path / "public", ignore_errors=True)
         workflow.private_workflow(cfg)
@@ -60,12 +66,16 @@ class TestManualWorkflowEndToEnd:
 
 def test_manual_cycle(tmp_path):
     cfg = tmp_path / "config.yaml"
-    profile = tmp_path / "profile.yaml"
-    template = tmp_path / "template"
-    template.mkdir()
-    (template / "f.txt").write_text("z={{Z}}\n")
-    profile.write_text("Z: 9\n")
-    cfg.write_text(f"profile: \"{profile}\"\ntemp_dir: \"{tmp_path}\"\ntemplate: \"{template}\"\n")
+    placeholder_values = tmp_path / "profile.yaml"
+    template_source_dir = tmp_path / "template"
+    template_source_dir.mkdir()
+    (template_source_dir / "f.txt").write_text("z={{Z}}\n")
+    placeholder_values.write_text("Z: 9\n")
+    cfg.write_text(
+        f"placeholder_values: \"{placeholder_values.as_posix()}\"\n"
+        f"working_directory: \"{tmp_path.as_posix()}\"\n"
+        f"template_source_dir: \"{template_source_dir.as_posix()}\"\n"
+    )
 
     workflow.private_workflow(cfg)
     public_dir = workflow.public_workflow(cfg)

--- a/tests/integration/test_workflow_suite.py
+++ b/tests/integration/test_workflow_suite.py
@@ -7,21 +7,24 @@ import workflow
 
 
 def test_complete_workflow(tmp_path):
-    template = tmp_path / "template"
-    template.mkdir()
-    (template / "a.txt").write_text("A={{A}}\n")
-    (template / "b.txt").write_text("B={{B}}\n")
+    template_source_dir = tmp_path / "template"
+    template_source_dir.mkdir()
+    (template_source_dir / "a.txt").write_text("A={{A}}\n")
+    (template_source_dir / "b.txt").write_text("B={{B}}\n")
 
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "secret.txt").write_text("S={{S}}\n")
+    company_only_files = tmp_path / "overlay"
+    company_only_files.mkdir()
+    (company_only_files / "secret.txt").write_text("S={{S}}\n")
 
-    profile = tmp_path / "profile.yaml"
-    profile.write_text("A: 1\nB: 2\nS: 3\n")
+    placeholder_values = tmp_path / "profile.yaml"
+    placeholder_values.write_text("A: 1\nB: 2\nS: 3\n")
 
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        f"profile: '{profile}'\ntemp_dir: '{tmp_path}'\ntemplate: '{template}'\noverlay_dir: '{overlay}'\n"
+        f"placeholder_values: '{placeholder_values.as_posix()}'\n"
+        f"working_directory: '{tmp_path.as_posix()}'\n"
+        f"template_source_dir: '{template_source_dir.as_posix()}'\n"
+        f"company_only_files: '{company_only_files.as_posix()}'\n"
     )
 
     private_dir = workflow.private_workflow(cfg)
@@ -36,16 +39,18 @@ def test_complete_workflow(tmp_path):
 
 
 def test_edge_case_class_names(tmp_path):
-    template = tmp_path / "template"
-    template.mkdir()
-    (template / "client.py").write_text("class {{ COMPANY_NAME }}Client:\n    pass\n")
+    template_source_dir = tmp_path / "template"
+    template_source_dir.mkdir()
+    (template_source_dir / "client.py").write_text("class {{ COMPANY_NAME }}Client:\n    pass\n")
 
-    profile = tmp_path / "profile.yaml"
-    profile.write_text("COMPANY_NAME: ACME\n")
+    placeholder_values = tmp_path / "profile.yaml"
+    placeholder_values.write_text("COMPANY_NAME: ACME\n")
 
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        f"profile: '{profile}'\ntemp_dir: '{tmp_path}'\ntemplate: '{template}'\n"
+        f"placeholder_values: '{placeholder_values.as_posix()}'\n"
+        f"working_directory: '{tmp_path.as_posix()}'\n"
+        f"template_source_dir: '{template_source_dir.as_posix()}'\n"
     )
 
     private_dir = workflow.private_workflow(cfg)
@@ -56,17 +61,19 @@ def test_edge_case_class_names(tmp_path):
 
 
 def test_binary_file_protection(tmp_path):
-    template = tmp_path / "template"
-    template.mkdir()
+    template_source_dir = tmp_path / "template"
+    template_source_dir.mkdir()
     data = b"\x00\x01\x02\x03"
-    (template / "file.bin").write_bytes(data)
+    (template_source_dir / "file.bin").write_bytes(data)
 
-    profile = tmp_path / "profile.yaml"
-    profile.write_text("TOKEN: secret\n")
+    placeholder_values = tmp_path / "profile.yaml"
+    placeholder_values.write_text("TOKEN: secret\n")
 
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        f"profile: '{profile}'\ntemp_dir: '{tmp_path}'\ntemplate: '{template}'\n"
+        f"placeholder_values: '{placeholder_values.as_posix()}'\n"
+        f"working_directory: '{tmp_path.as_posix()}'\n"
+        f"template_source_dir: '{template_source_dir.as_posix()}'\n"
     )
 
     private_dir = workflow.private_workflow(cfg)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -18,8 +18,8 @@ class MockGitHub:
 
 class MockGitRepository:
     """Mock git operations for predictable testing"""
-    def __init__(self, temp_dir: Path):
-        self.repo_dir = temp_dir
+    def __init__(self, working_directory: Path):
+        self.repo_dir = working_directory
         self.commits = []
         self.branches = {"main": None}
         self.current_branch = "main"

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -9,16 +9,21 @@ import pytest
 
 def test_private_public_cycle(tmp_path):
     cfg = tmp_path / 'config.yaml'
-    profile = tmp_path / 'profile.yaml'
-    template = tmp_path / 'template'
-    overlay = tmp_path / 'overlay'
-    work = tmp_path / 'work'
-    template.mkdir()
-    overlay.mkdir()
-    (template / 'a.txt').write_text('x={{X}}\n')
-    (overlay / 'b.txt').write_text('y={{Y}}\n')
-    profile.write_text('X: 1\nY: 2\n')
-    cfg.write_text(f'profile: "{profile}"\noverlay_dir: "{overlay}"\ntemp_dir: "{work}"\ntemplate: "{template}"\n')
+    placeholder_values = tmp_path / 'profile.yaml'
+    template_source_dir = tmp_path / 'template'
+    company_only_files = tmp_path / 'overlay'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    company_only_files.mkdir()
+    (template_source_dir / 'a.txt').write_text('x={{X}}\n')
+    (company_only_files / 'b.txt').write_text('y={{Y}}\n')
+    placeholder_values.write_text('X: 1\nY: 2\n')
+    cfg.write_text(
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'company_only_files: "{company_only_files.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
+    )
 
     private_dir = workflow.private_workflow(cfg)
     assert (private_dir / 'a.txt').read_text() == 'x=1\n'
@@ -31,17 +36,19 @@ def test_private_public_cycle(tmp_path):
 
 def test_private_public_dry_run(tmp_path):
     cfg = tmp_path / 'config.yaml'
-    profile = tmp_path / 'profile.yaml'
-    template = tmp_path / 'template'
-    overlay = tmp_path / 'overlay'
-    work = tmp_path / 'work'
-    template.mkdir()
-    overlay.mkdir()
-    (template / 'a.txt').write_text('x={{X}}\n')
-    profile.write_text('X: 1\n')
+    placeholder_values = tmp_path / 'profile.yaml'
+    template_source_dir = tmp_path / 'template'
+    company_only_files = tmp_path / 'overlay'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    company_only_files.mkdir()
+    (template_source_dir / 'a.txt').write_text('x={{X}}\n')
+    placeholder_values.write_text('X: 1\n')
     cfg.write_text(
-        f'profile: "{profile}"\noverlay_dir: "{overlay}"\ntemp_dir: "{work}"\n'
-        f'template: "{template}"\n'
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'company_only_files: "{company_only_files.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
     )
 
     private_dir = workflow.private_workflow(cfg, dry_run=True)
@@ -69,18 +76,20 @@ def test_repo_status_nested(monkeypatch):
 
 def test_overlay_override_removed(tmp_path):
     cfg = tmp_path / 'c.yaml'
-    profile = tmp_path / 'p.yaml'
-    template = tmp_path / 'template'
-    overlay = tmp_path / 'overlay'
-    work = tmp_path / 'work'
-    template.mkdir()
-    overlay.mkdir()
-    (template / 'a.txt').write_text('orig={{A}}')
-    (overlay / 'a.txt').write_text('private={{A}}')
-    profile.write_text('A: 1')
+    placeholder_values = tmp_path / 'p.yaml'
+    template_source_dir = tmp_path / 'template'
+    company_only_files = tmp_path / 'overlay'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    company_only_files.mkdir()
+    (template_source_dir / 'a.txt').write_text('orig={{A}}')
+    (company_only_files / 'a.txt').write_text('private={{A}}')
+    placeholder_values.write_text('A: 1')
     cfg.write_text(
-        f'profile: "{profile}"\noverlay_dir: "{overlay}"\ntemp_dir: "{work}"\n'
-        f'template: "{template}"\n'
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'company_only_files: "{company_only_files.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
     )
 
     private_dir = workflow.private_workflow(cfg)
@@ -92,18 +101,20 @@ def test_overlay_override_removed(tmp_path):
 
 def test_overlay_manifest_used_when_overlay_missing(tmp_path, monkeypatch):
     cfg = tmp_path / 'c.yaml'
-    profile = tmp_path / 'p.yaml'
-    template = tmp_path / 'template'
-    overlay = tmp_path / 'overlay'
-    work = tmp_path / 'work'
-    template.mkdir()
-    overlay.mkdir()
-    (template / 'base.txt').write_text('x={{X}}')
-    (overlay / 'secret.txt').write_text('s={{S}}')
-    profile.write_text('X: 1\nS: 2')
+    placeholder_values = tmp_path / 'p.yaml'
+    template_source_dir = tmp_path / 'template'
+    company_only_files = tmp_path / 'overlay'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    company_only_files.mkdir()
+    (template_source_dir / 'base.txt').write_text('x={{X}}')
+    (company_only_files / 'secret.txt').write_text('s={{S}}')
+    placeholder_values.write_text('X: 1\nS: 2')
     cfg.write_text(
-        f'profile: "{profile}"\noverlay_dir: "{overlay}"\ntemp_dir: "{work}"\n'
-        f'template: "{template}"\n'
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'company_only_files: "{company_only_files.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
     )
 
     private_dir = workflow.private_workflow(cfg)
@@ -111,14 +122,14 @@ def test_overlay_manifest_used_when_overlay_missing(tmp_path, monkeypatch):
     assert (private_dir / '.overlay_manifest').exists()
 
     # Remove overlay directory before running public workflow
-    shutil.rmtree(overlay)
+    shutil.rmtree(company_only_files)
 
     captured = {}
     original_remove = workflow._remove_overlay
 
-    def spy(public_dir, template_dir, overlay_dir, overlay_files=None):
+    def spy(public_dir, template_dir, company_only_files_dir, overlay_files=None):
         captured["files"] = overlay_files
-        return original_remove(public_dir, template_dir, overlay_dir, overlay_files)
+        return original_remove(public_dir, template_dir, company_only_files_dir, overlay_files)
 
     monkeypatch.setattr(workflow, "_remove_overlay", spy)
 
@@ -138,14 +149,16 @@ def test_overlay_manifest_used_when_overlay_missing(tmp_path, monkeypatch):
 
 def test_public_workflow_runs_verification(tmp_path, monkeypatch):
     cfg = tmp_path / 'c.yaml'
-    profile = tmp_path / 'p.yaml'
-    template = tmp_path / 'template'
-    work = tmp_path / 'work'
-    template.mkdir()
-    (template / 'a.txt').write_text('x={{X}}')
-    profile.write_text('X: 1')
+    placeholder_values = tmp_path / 'p.yaml'
+    template_source_dir = tmp_path / 'template'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    (template_source_dir / 'a.txt').write_text('x={{X}}')
+    placeholder_values.write_text('X: 1')
     cfg.write_text(
-        f'profile: "{profile}"\ntemp_dir: "{work}"\ntemplate: "{template}"\n'
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
     )
 
     captured = {}
@@ -158,21 +171,23 @@ def test_public_workflow_runs_verification(tmp_path, monkeypatch):
 
     public_dir = workflow.public_workflow(cfg)
 
-    assert captured['args'][0] == template
+    assert captured['args'][0] == template_source_dir
     assert captured['args'][1] == public_dir
     assert captured['args'][2] is None
 
 
 def test_public_workflow_verification_failure(tmp_path, monkeypatch):
     cfg = tmp_path / 'c.yaml'
-    profile = tmp_path / 'p.yaml'
-    template = tmp_path / 'template'
-    work = tmp_path / 'work'
-    template.mkdir()
-    (template / 'a.txt').write_text('x={{X}}')
-    profile.write_text('X: 1')
+    placeholder_values = tmp_path / 'p.yaml'
+    template_source_dir = tmp_path / 'template'
+    working_directory = tmp_path / 'work'
+    template_source_dir.mkdir()
+    (template_source_dir / 'a.txt').write_text('x={{X}}')
+    placeholder_values.write_text('X: 1')
     cfg.write_text(
-        f'profile: "{profile}"\ntemp_dir: "{work}"\ntemplate: "{template}"\n'
+        f'placeholder_values: "{placeholder_values.as_posix()}"\n'
+        f'working_directory: "{working_directory.as_posix()}"\n'
+        f'template_source_dir: "{template_source_dir.as_posix()}"\n'
     )
 
     monkeypatch.setattr(workflow, 'verify_public_export', lambda *a, **k: False)


### PR DESCRIPTION
## Summary
- replace `profile`, `template`, `temp_dir`, and `overlay_dir` config keys with clearer names
- add backward compatible config loader that warns when deprecated keys are used
- update documentation and example configuration to reference new parameter names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b58e1191f48333b4dc92802792e076